### PR TITLE
New events: panstart, pan, panend

### DIFF
--- a/Tocca.js
+++ b/Tocca.js
@@ -98,7 +98,7 @@
 
       // clear the previous timer in case it was set
       clearTimeout(tapTimer);
-		
+	
       if (deltaX <= -swipeTreshold)
         eventsArr.push('swiperight');
 
@@ -150,16 +150,15 @@
       var pointer = getPointerEvent(e);
       currX = pointer.pageX;
       currY = pointer.pageY;
-		
+
       if (tapNum > 0) {
         if (panStarted) {
-         sendEvent(e.target, 'pan', e);	
+          sendEvent(e.target, 'pan', e);	
         } else {
-           if ((timestamp + tapTreshold) - getTimestamp() >= 0) {
-	           sendEvent(e.target, 'panstart', e);
-	           panStarted = true;
-			  }
-         
+          if ((timestamp + tapTreshold) - getTimestamp() >= 0) {
+	    sendEvent(e.target, 'panstart', e);
+	    panStarted = true;
+          }
         }
       }
     },

--- a/Tocca.js
+++ b/Tocca.js
@@ -112,7 +112,7 @@
         eventsArr.push('swipeup');
 
       if (panStarted) {
-		  eventsArr.push('panend');
+        eventsArr.push('panend');
         panStarted = false;		  
       }
 

--- a/Tocca.js
+++ b/Tocca.js
@@ -98,7 +98,7 @@
 
       // clear the previous timer in case it was set
       clearTimeout(tapTimer);
-
+		
       if (deltaX <= -swipeTreshold)
         eventsArr.push('swiperight');
 
@@ -110,6 +110,12 @@
 
       if (deltaY >= swipeTreshold)
         eventsArr.push('swipeup');
+
+      if (panStarted) {
+		  eventsArr.push('panend');
+        panStarted = false;		  
+      }
+
       if (eventsArr.length) {
         for (var i = 0; i < eventsArr.length; i++) {
           var eventName = eventsArr[i];
@@ -144,7 +150,20 @@
       var pointer = getPointerEvent(e);
       currX = pointer.pageX;
       currY = pointer.pageY;
+		
+      if (tapNum > 0) {
+        if (panStarted) {
+         sendEvent(e.target, 'pan', e);	
+        } else {
+           if ((timestamp + tapTreshold) - getTimestamp() >= 0) {
+	           sendEvent(e.target, 'panstart', e);
+	           panStarted = true;
+			  }
+         
+        }
+      }
     },
+    panStarted = false,
     swipeTreshold = win.SWIPE_TRESHOLD || 80,
     tapTreshold = win.TAP_TRESHOLD || 200, // range of time where a tap event could be detected
     dbltapTreshold = win.DBL_TAP_TRESHOLD || 50, // delay needed to detect a double tap


### PR DESCRIPTION
This pull request proposes three new events, 'panstart', 'pan', and 'panend', to enable tracking of  touchmove gesture during drag-and-drop scenarios. It works by setting a a new boolean flag, 'panStarted' in the touchmove handler, which fires the 'panstart' event the first time, and then 'pan' events in subsequent times, until touchend resets panStarted to false.