### PR TITLE
Add semicolon the the end of Tocca.js

### DIFF
--- a/Tocca.js
+++ b/Tocca.js
@@ -179,4 +179,4 @@
   setListener(doc, touchevents.touchstart + (justTouchEvents ? '' : ' mousedown'), onTouchStart)
   setListener(doc, touchevents.touchend + (justTouchEvents ? '' : ' mouseup'), onTouchEnd)
   setListener(doc, touchevents.touchmove + (justTouchEvents ? '' : ' mousemove'), onTouchMove)
-}(document, window))
+}(document, window));


### PR DESCRIPTION
Missing `;` at the end of file caused `intermediate value(…) is not a function` error when used with some types of js modules.